### PR TITLE
DB용 docker compose 관련 파일 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM openjdk:17-jdk-slim As builder
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+
+FROM openjdk:17-jdk-slim
+COPY --from=builder build/libs/*.jar app.jar
+
+EXPOSE 8080
+#ENTRYPOINT ["java", "-Dspring.profiles.active=dev,console-log,file-log", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  db:
+    image: mysql:5.7
+    container_name: member-manager-mysql
+    restart: always
+    platform: linux/amd64
+    ports:
+      - 3306:3306
+    networks:
+      - db-net
+    volumes:
+      - member-manager-db-data:/etc/data
+    environment:
+      MYSQL_DATABASE: member_manager
+      MYSQL_ROOT_PASSWORD: member1234
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_USER: member
+      MYSQL_PASSWORD: m1234
+      TZ: Asia/Seoul
+    command: [ "mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_general_ci" ]
+  web:
+    container_name: member-manager-server
+    restart: always
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - 8080:8080
+    networks:
+      - db-net
+    depends_on:
+      - db
+
+networks:
+  db-net:
+    driver: bridge
+
+volumes:
+  member-manager-db-data:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/member_manager
+    url: jdbc:mysql://member-manager-mysql:3306/member_manager
     username: member
     password: m1234
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
<!-- If you don't have anything to write about on a topic, you don't have to. -->

### Description<!-- A clear and concise description of pull request -->
mysql DB 를 통해 회원 관리를 할 수 있도록 docker 파일을 생성하였습니다.

`docker compose up -d --build` 명령어를 통해서 디비와 서비스를 실행할 수 있습니다.

- TODO
docker compose 로 실행할 때 DB 가 온전히 실행되기 전에 web 컨테이너가 DB 에 접근하여 restart 를 여러번 하는 문제가 있습니다.
추후 해결해야 합니다.

### Tasks<!-- Summary of what to do -->
1. docker compose 생성
2. Dockerfile 생성
3. application.yml 생성
4. application-dev.yml 생성

### Expected behaviour<!-- Tell us what should happen -->
1. `docker compose up -d --build` 를 통해서 서비스를 실행할 수 있습니다.

### Tests<!-- How can we test that it works? -->

### Note to reviewers

### Reference image<!-- Images to help us understand your work -->

---
#### Resolves # <!-- Resolved issues-->
